### PR TITLE
Less verbose `--opentype-*` custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,22 +231,22 @@ Handy utility classes showing how to access the font feature values you set up e
 
 ```
 :root {
-    --opentype-case: "case" off;
-    --opentype-sinf: "sinf" off;
+    --opentype-case: off;
+    --opentype-sinf: off;
 }
 
 /* If class is applied, update custom property */
 .case {
-    --opentype-case: "case" on;
+    --opentype-case: on;
 }
 
 .sinf {
-    --opentype-sinf: "sinf" on;
+    --opentype-sinf: on;
 }
 
 /* Apply current state of all custom properties, defaulting to off */
-* { 
-    font-feature-settings: var(--opentype-case, "case" off), var(--opentype-sinf, "sinf" off);
+* {
+    font-feature-settings: "case" var(--opentype-case, off), "sinf" var(--opentype-sinf, off);
 }
 ```
 
@@ -268,7 +268,7 @@ When centring text you’ll almost always want the text to be ‘balanced’, me
 ```
 .uppercase {
     text-transform: uppercase;
-    --opentype-case: "case" on;
+    --opentype-case: on;
 }
 ```
 
@@ -363,8 +363,8 @@ Use proper super- and subscript characters. Apply to `SUB` and `SUP` elements as
 If font-variant-position is not specified, browsers will synthesise sub/superscripts, so we need to manually turn off the synthesis. This is the only way to use a font’s proper sub/sup glyphs, however it’s **only safe to use this if** you know your font has glyphs for all the characters you are sub/superscripting. If the font lacks those characters (most only have sub/superscript numbers, not letters), then only Firefox (correctly) synthesises sup and sub - all other browsers will display normal characters in the regular way as we turned the synthesis off.
 
 ```
-.chemical { 
-    --opentype-sinf: "sinf" on;
+.chemical {
+    --opentype-sinf: on;
 }
 ```
 

--- a/tods.css
+++ b/tods.css
@@ -142,14 +142,14 @@ button, input, label {
 .nalt2 { font-variant-alternates: annotation(boxed); }
 
 :root {
-    --opentype-case: "case" off;
-    --opentype-sinf: "sinf" off;
+    --opentype-case: off;
+    --opentype-sinf: off;
 }
-.case { --opentype-case: "case" on; }
-.sinf { --opentype-sinf: "sinf" on; }
+.case { --opentype-case: on; }
+.sinf { --opentype-sinf: on; }
 
-* { 
-    font-feature-settings: var(--opentype-case, "case" off), var(--opentype-sinf, "sinf" off);
+* {
+    font-feature-settings: "case" var(--opentype-case, off), "sinf" var(--opentype-sinf, off);
 }
 
 
@@ -164,7 +164,7 @@ button, input, label {
 
 .uppercase {
     text-transform: uppercase;
-    --opentype-case: "case" on;
+    --opentype-case: on;
 }
 
 .smallcaps {
@@ -229,8 +229,8 @@ h1.uppercase {
     }
 }
 
-.chemical { 
-    --opentype-sinf: "sinf" on;
+.chemical {
+    --opentype-sinf: on;
 }
 
 /*


### PR DESCRIPTION
Forgive me if you considered and decided against this. In my head it seems a touch _nicer_ (mostly vibe-based) not having to redeclare the OpenType font feature in declarations for custom properties like `--opentype-case` and `--opentype-sinf`

Set fallback/default values much like `--vf-grad` is done…

```css
* {
	font-feature-settings:
		'case' var(--opentype-case, off),
		'sinf' var(--opentype-sinf, off);
}
```

…and then the `--opentype-*` properties become a little more vanilla-property-like:

```css
.case { --opentype-case: on; }
```

In any case, **thank you** for creating and publishing TODS! This `font-feature-settings` setup had the biggest 🤯-factor for me (already adopted it!); but I _know_ I’ll be coming back to this for a long time 🙏